### PR TITLE
Devel Evolution: batch bugfixes part one

### DIFF
--- a/global.R
+++ b/global.R
@@ -7,6 +7,7 @@ suppressPackageStartupMessages({
     library(shiny)
     library(shinydashboard)
     library(shinycssloaders)
+    library(shinyBS)
     library(sortable)
     # library(shinyWidgets)
     library(plotly)

--- a/server.R
+++ b/server.R
@@ -143,7 +143,6 @@ server <- function(input, output, session) {
         handlerExpr = {
             init_vals$basedata_change_reloads_plots <- FALSE
 
-            print("GADZOOKS")
             spatial_list <- lapply(rapply(input$MAPDATA, enquote, how = "unlist"), eval)
             sites_list <- c()
 
@@ -161,15 +160,9 @@ server <- function(input, output, session) {
                 site_pairs[[i]] <- pair
             }
 
-            print("SKOOZDAG")
-
             site_all <- c()
             dmns <- c()
             dmn_all <- c()
-            print("woop")
-            print(dmn_all)
-            print(site_all)
-            print(dmns)
 
             for (unit in site_pairs) {
                 # get domain and site

--- a/ui/info_tab.html
+++ b/ui/info_tab.html
@@ -1,0 +1,85 @@
+<div class = "notes" style="overflow-y: scroll; height: 300px; padding: 20px;">
+   <!-- <h4> Macrosheds Site Notes </h4> -->
+  <div class="panel-group" id="accordion">
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h4 class="panel-title">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#collapseOne">
+              Map
+            </a>
+          </h4>
+        </div>
+        <div id="collapseOne" class="panel-collapse collapse">
+          <div class="panel-body">
+              <ul>
+                 <li>
+                     the map contains <span style="color: blue;"> rain gauges</span> and <span style="color: purple;"> stream chemistry gauges</span>
+                     from the MacroSheds dataset
+                 </li>
+                 <li>
+                     stream chemistry gauges will have a <strong>blue plus sign</strong> -- click this icon to add the site to your bucket in the "Selected Sites" tab
+                 </li>
+                 <li>
+                     use the square icon in the upper right of the map to control which layers of geospatial data to visualize on the map
+                 </li>
+                 <li>
+                     use the blue "Legend" button (or on small screens, the grey list icon) to choose legends to appear or dissappear on the map (click a layer name to make the legend appear, and click again to make it go away)
+                 </li>
+              </ul>
+          </div>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h4 class="panel-title">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo">
+                Selected Sites
+            </a>
+          </h4>
+        </div>
+        <div id="collapseTwo" class="panel-collapse collapse">
+          <div class="panel-body">
+            <ul>
+                <li>
+                    the "Selected Sites" tab contains a <em>rank list</em>, storing sites a user adds from the above map <em>(see the map information section for more detail)</em>
+                </li>
+
+                <li>
+                    once a user adds a site to this bucket, they may notice that the blue <span style="color:blue;">Plot</span>
+                    button flashes orange- this reflects that the user must click the plot button to see the added sites data
+                    in the time series graphs
+                </li>
+
+                <li>
+                    users should be aware that the rank list provides data to the time series and site comparison tabs, but manipulating inputs there, won't effect your list
+                </li>
+                <li>
+                    the top three rank list items are supplied to the Time Series tab (color coded with line color in the graphs), while the site comparison tab uses the entire rank list
+                </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="panel panel-default">
+        <div class="panel-heading">
+          <h4 class="panel-title">
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#collapseThree">
+                Watershed
+            </a>
+          </h4>
+        </div>
+        <div id="collapseThree" class="panel-collapse collapse">
+          <div class="panel-body">
+            <ul>
+                <li>
+                        the Watershed tab provides a table of supplemental information about the top ranked site in the rank list
+                </li>
+                <li>
+                        we are working on making it so that, when the map view is expanded (using the arrows at the middle top of the website), this tab becomes a scrollable data table containing attribute data of every site in the rank list
+                </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+  </div>
+</div> <!-- end container -->

--- a/ui/map_ui.R
+++ b/ui/map_ui.R
@@ -33,6 +33,7 @@ map_tab <- tabPanel(
                 type = "tabs",
                 tabPanel(
                     "Selected Sites",
+                    style = "overflow-y:scroll; height: 300px;",
                     rank_list_basic,
                 ),
                 tabPanel(

--- a/ui/map_ui.R
+++ b/ui/map_ui.R
@@ -15,7 +15,14 @@ map_tab <- tabPanel(
         column(
             width = 12,
             div(
+                id = "legend-container",
                 style = "position: absolute; right: 4em",
+                bsTooltip(
+                    id = "legend-container",
+                    title = "this is a BETA legend, improved legend coming soon",
+                    placement = "bottom",
+                    trigger = "hover"
+                ),
                 HTML('<div class="dropup" id="legend-button"><button class="btn btn-primary dropdown-toggle" type="button" id="about-us" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Legend <span class="caret"></span></button><ul class="dropdown-menu" aria-labelledby="legend-drop"><li><a id="3DEP-Leg" href="#">3DEP Elevation</a></li><li><a id="Tree-Leg" href="#">Tree Canopy</a></li><li><a id="Impervious-Leg" href="#">Impervious Surfaces</a></li><li><a id="Landcover-Leg" href="#">Landcover</a></li><li><a id="LCChange-Leg" href="#">Landcover Change</a></li><li><a id="Geology-Leg" href="#">Geology</a></li></ul></div>')
                 # <li><a id="Ecoregions" href="#">Ecoregions</a></li> <li><a id="TreeCanopyChange-Leg" href="#">Tree Canopy Change</a></li>
             ),
@@ -31,13 +38,23 @@ map_tab <- tabPanel(
             tabsetPanel(
                 id = "attribute-content",
                 type = "tabs",
+                selected = "Selected Sites",
                 tabPanel(
+                    id = "bucket-info",
+                    HTML('<span class="glyphicon glyphicon-question-sign"></span>'),
+                    div(
+                        includeHTML("ui/info_tab.html"),
+                        # style = "padding: 20px"
+                    ),
+                ),
+                tabPanel(
+                    id = "site-bucket",
                     "Selected Sites",
                     style = "overflow-y:scroll; height: 300px;",
                     rank_list_basic,
                 ),
                 tabPanel(
-                    "Watershed Attributes",
+                    "Watershed",
                     # textOutput("MAP_SITE_INFO_TITLE"),
                     tableOutput("MAP_SITE_INFO") %>%
                         tagAppendAttributes(class = "table") %>%
@@ -59,9 +76,6 @@ map_tab <- tabPanel(
                 id = "notes-footer",
                 "go to 'Notes/Caveats' tab for more information"
             ),
-            tags$footer(
-                textOutput("results_basic")
-            )
             # class = "leftpanel-text"
         )
     )

--- a/ui/nSiteNVar_ui.R
+++ b/ui/nSiteNVar_ui.R
@@ -6,7 +6,7 @@ nSiteNVar_tab <- tabPanel("Time Series",
             div(
                 class = "text-center",
                 actionButton("GEN_PLOTS3",
-                    "Update Plots",
+                    "Plot",
                     class = "text-center, btn btn-block btn-primary",
                 )
             ),

--- a/ui/rain_gauge_buttons.html
+++ b/ui/rain_gauge_buttons.html
@@ -1,9 +1,23 @@
 <div style='text-align: center'>
-    {domain}-{site_code}
+
+<!-- <button class="well">{domain}  {site_code}</button> -->
+
+<ul class="list-group" style="margin-bottom: 0px;">
+<li class="list-group-item">
+<span class="badge" style="float: left;">domain</span>
+<strong>{domain}</strong>
+</li>
+<li class="list-group-item">
+<span class="badge" style="float: left;">rain gauge</span>
+{site_code}
+</li>
+</ul>
+
 </div>
 <button data-toggle='collapse' class='btn btn-sm btn-link btn-block'
     data-target='#{domain}__{site_code}_collapse'>
 </button>
+<!-- <span class="glyphicon glyphicon-tint"></span> -->
 <div id='{domain}__{site_code}_collapse' class='collapse'>
 
 </div>

--- a/ui/stream_gauge_buttons.html
+++ b/ui/stream_gauge_buttons.html
@@ -1,18 +1,39 @@
+<button data-toggle='collapse' class='btn btn-sm btn-link btn-block'
+    data-target='#{domain}__{site_code}_collapse'>
+</button>
+
 <div style='text-align: center'>
-    {domain}-{site_code}
+
+<!-- <button class="well">{domain}  {site_code}</button> -->
+
+<ul class="list-group" style="margin-bottom: 0px;">
+<li class="list-group-item">
+<span class="badge" style="float: left;">domain</span>
+<strong>{domain}</strong>
+</li>
+<li class="list-group-item">
+<span class="badge" style="float: left;">chemistry gauge</span>
+{site_code}
+</li>
+</ul>
+
 </div>
 <button data-toggle='collapse' class='btn btn-sm btn-link btn-block'
     data-target='#{domain}__{site_code}_collapse'>
 </button>
-<div id='{domain}__{site_code}_collapse' class='collapse'>
-</div>
 
-<div class="" style="margin-left: 30% ">
-    <button class='btn btn-sm btn-primary' id='{domain}__{site_code}_goto' >
+<div class="" style="margin-left: 42% ">
+    <!-- <button class='btn btn-sm btn-primary' id='{domain}__{site_code}_goto' >
         go to
-    </button>
+    </button> -->
 
     <button class='btn btn-sm btn-primary' id='{domain}__{site_code}_goto' style="">
-        <span class="glyphicon glyphicon-plus"></span>
+        <a target="_blank" data-toggle="tooltip" data-placement="bottom" title="click to add this site to the selected sites bucket below!">
+            <span class="glyphicon glyphicon-plus"></span>
+        </a>
     </button>
+</div>
+
+<div id='{domain}__{site_code}_collapse' class='collapse'>
+
 </div>

--- a/www/app.css
+++ b/www/app.css
@@ -925,3 +925,28 @@ tbody tr.active-row {
     border: 3px solid #d88546 !important;
     margin-bottom: 2px;
 }
+
+/* button attention animation, plots */
+@-webkit-keyframes btn-update {
+    from, to {
+        border-color: transparent
+    }
+    50% {
+        border-color: orange
+    }
+}
+
+@keyframes btn-update {
+    from, to {
+        border-color: transparent
+    }
+    50% {
+        border-color: orange
+    }
+}
+
+.btn-update {
+    border: 1px solid orange;
+    -webkit-animation: btn-update 2s step-end infinite;
+    animation: btn-update 2s step-end infinite;
+}

--- a/www/js/general.js
+++ b/www/js/general.js
@@ -84,6 +84,9 @@ shinyjs.init = function() {
             // make "PLOT" button attention styled
             $("#GEN_PLOTS3").addClass("btn-update");
 
+            // make site comparison option highlight as well?
+            // $('value="BY_BUCKET2"').addClass("btn-update");
+
             $('#SITE_EXPLORE').trigger('click');
 
             // extract domain and site name, clean

--- a/www/js/general.js
+++ b/www/js/general.js
@@ -81,18 +81,29 @@ shinyjs.init = function() {
 
             var goto_id = $(this).attr('id') // + new Date(); //trigger reactivity
 
+            // make "PLOT" button attention styled
+            $("#GEN_PLOTS3").addClass("btn-update");
+
             $('#SITE_EXPLORE').trigger('click');
+
+            // extract domain and site name, clean
+            site_info = goto_id.split('_');
+            site_info_end = site_info.length -1
+
+            // var site = site_info[2];
+            var domain = site_info[0];
+            var site = site_info.slice(1, site_info_end).join(' ');
 
             // add sites to cart
             $('div').find('.rank-list').prepend(
-                    '<div class="rank-list-item" id =' + goto_id + 'remover' + ' draggable="false">' + goto_id + ' <button type="button" class="btn btn-default btn-sm rankremover" style="float: right"><span class="glyphicon glyphicon-remove"></span> </button></div>'
+                    '<div class="rank-list-item" id =' + goto_id + 'remover' + ' draggable="false">' + '<strong>' + domain + '</strong>' + ':  ' + site + ' <button type="button" class="btn btn-default btn-sm rankremover" style="float: right"><span class="glyphicon glyphicon-remove"></span> </button></div>'
                 );
 
             // set mapdata as top 3 ranks
             var rankList = [];
 
             $(".rank-list > .rank-list-item").each((index, elem) => {
-              rankList.push(elem.innerHTML);
+              rankList.push(elem.id);
             });
             console.log(rankList)
 
@@ -289,6 +300,10 @@ shinyjs.init = function() {
 
     $('body').ready(function(){
         $('#GEN_PLOTS3').click(govern_qc3);
+        $('#GEN_PLOTS3').click( function() {
+            $(this).removeClass("btn-update");
+            // $(this).addClass("btn-primary");
+        });
     });
 
     //BIPLOT: disable X-axis selection when aggregation == 'Yearly'
@@ -1009,42 +1024,7 @@ $(document).ready(function() {
     };
 });
 
-// auto-rotate
-// $(document).ready( function() {
-//     var intervalId = window.setInterval(function(){
-//       plusSlides(slideIndex);
-//       // console.log('a seocnd has passed');
-//   }, 8000);
-// })
-// var carouselCount = 0;
-//
-
-// $(document).ready( function() {
-//     var intervalId = window.setInterval(function(){
-//       slideIndex++;
-//       carouselCount++;
-//
-//       showSlides(slideIndex);
-//       console.log(slideIndex);
-//   }, 10000);
-//
-//     var intervalStop = window.setInterval(function(){
-//       clearInterval(intervalId);
-//       var slideIndex = 2;
-//   }, 50000);
-//
-// })
-//
-// $(document).ready( function() {
-//     $('.update-slide').addClass('update');
-//     setTimeout(
-//       function()
-//           {
-//               $('.update-slide').removeClass('update');
-//           }, 11000);
-// })
-
-// single use function funciton
+//  orange attention animation funciton
 $(document).ready( function() {
     var intervalUpdate = window.setInterval(function(){
         $('#macrosheds-dot').addClass('update');
@@ -1060,6 +1040,22 @@ $(document).ready( function() {
           }
       );
 })
+
+// $(document).ready( function() {
+//     var intervalUpdate = window.setInterval(function(){
+//         $('.btn-update').css('border', '0px;');
+//         setTimeout(
+//           function()
+//               {
+//                   $('.btn-update').css('0px solid orange;');
+//               }, 500);
+//       }, 1000);
+//
+//       // $('#').click( function() {
+//       //         clearInterval(intervalUpdate);
+//       //     }
+//       // );
+// })
 
 var dotExcited = 0;
 
@@ -1088,6 +1084,33 @@ $(document).ready( function() {
       }
   })
 
+// var dotExcited = 0;
+//
+// $(document).ready( function() {
+//           if (dotExcited == 0) {
+//               $('#macrosheds-dot').click( function() {
+//                 if (dotExcited == 0) {
+//                 var intervalUpdate = window.setInterval(function(){
+//                     $('#macrosheds-dot-two').addClass('update');
+//                     setTimeout(
+//                       function()
+//                           {
+//                               $('#macrosheds-dot-two').removeClass('update');
+//                           }, 500);
+//                   }, 1000);
+//                 dotExcited++;
+//                 }
+//
+//                   $('#macrosheds-dot-two').click( function() {
+//                           clearInterval(intervalUpdate);
+//                           dotExcited++;
+//                       }
+//                   );
+//               }
+//           );
+//       }
+//   })
+
 // leflet legend
 function addLegend() {
     if ($('.diy-legend').length) {
@@ -1100,38 +1123,6 @@ function addLegend() {
         }, 3000);
         };
     };
-
-function sortLegend() {
-        var legendList = [];
-
-        $(".wms-legend").each((index, elem) => {
-          legendList.push(elem.src);
-        });
-
-        var legURL = [];
-
-        for (wms in legendList) {
-            legURL
-        }
-    };
-
-$(document).ready( function() {
-    sortLegend()
-});
-
-$(document).ready( function() {
-    $('#left_tabs').click( function() {
-        addLegend()
-        // $('#my-legend').click(function() {
-        //     console.log('WOOT');
-        //     // $(this).parent().find("span");
-        // })
-    });
-});
-
-function checkClick() {
-        console.log("YES THIS CLICK IS WORKING");
-};
 
 var legendsActive = 0;
 
@@ -1265,64 +1256,6 @@ $(document).ready(function() {
     layerClicks();
         });
 
-// Legend Dropdown
-// <div style="z-index: 900 !important;margin-top: 10px;" id="diy-legend" class="leaflet-control well">
-//
-//   <div class="dropdown">
-// <button class="btn btn-primary dropdown-toggle" type="button" id="about-us" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="">
-// About Us
-// <span class="caret"></span>
-// </button>
-// <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="about-us">
-// <li><a href="#">Our Story</a></li>
-// <li><a href="#">Our Team</a></li>
-// <li><a href="#">Contact Us</a></li>
-// </ul>
-// </div></div>
-
-// just dropdown
-//   <div class="dropdown">
-// <button class="btn btn-primary dropdown-toggle" type="button" id="about-us" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" style="">
-// About Us
-// <span class="caret"></span>
-// </button>
-// <ul class="dropdown-menu dropdown-menu-right" aria-labelledby="about-us">
-// <li><a href="#">Our Story</a></li>
-// <li><a href="#">Our Team</a></li>
-// <li><a href="#">Contact Us</a></li>
-// </ul>
-// </div>
-// Javascript to get Legend Labels
-// from URLs
-
-// var wmsDict = {
-//     'http://127.0.0.1:7027/mrlc_display/NLCD_Tree_Canopy_Change_I…g&width=20&height=20&layer=NLCD_Tree_Canopy_Change_Index_L48': "Tree Canopy Change",
-//     'https://www.mrlc.gov/geoserver/mrlc_display/NLCD_2016_Tree_C…age%2Fpng&width=20&height=20&layer=NLCD_2016_Tree_Canopy_L48': "Tree Canopy",
-//     'https://www.sciencebase.gov/arcgis/services/Catalog/5888bf4f…etLegendGraphic%26version=1.3.0%26format=image/png%26layer=0': "Geology",
-//
-// }
-
-
-// for (x in legendList) {
-//  for ( item in wmsDict) {
-//     if (legendList[x].src.toString().trim == item.toString().trim) {
-//       console.log(wmsDict[item]);
-//     }
-//   }
-// }
-
-// Layers Legend 'active' controls
-
-// 1) on click, layer populates 'active layer' variable
-// var activeLayer = ''
-
-// $(document).ready( function() {
-//     $('.leaflet-control-layers-list').on('input', function() {
-//         console.log('WOOT');
-//         // $(this).parent().find("span");
-//     })
-// })
-//
 $(document).ready( function() {
     $(window).on('resize', function() {
         if ($("#attribute-content").width() < 500) {
@@ -1340,8 +1273,5 @@ $(document).ready( function() {
         });
     });
 
- // $(document).ready( function() {
- //     $('#COLLAPSE_ATTRIBUTES').click();
- // })
 // 2) this variable triggers legend icon to be associated with legend or legend URL for active layer
 // 3) legend icon on click/hover displays legend visual


### PR DESCRIPTION
- popup rain gauges labeled
- popup styling
- info tab with instructions for Map, Sites Bucket, Watershed Attributes (and much room for more, and, improvement)
- tooltips for "plus" button and for "legend" including warning that legend is in Beta stage and improvements coming
- change "Update PLots" to "Plot"
- added attention (currently flashin orange border) when site bucket data changed but not yet plotted (note: I also tried changing    the class from **btn-primary** to **btn-warning** which was a bit assertive, but I kind of think looks good, maybe better than the flashing, which could get annoying. also note: could also extend attention plumbing to the "use slected sites" radio button in Site Comparison... as it is currently a tad subtle)
- deleted much relic code
- added scrollbar for site bucket