### PR TITLE
biplot color update (higher contrast)

### DIFF
--- a/server/summary_biplot_server.R
+++ b/server/summary_biplot_server.R
@@ -56,9 +56,8 @@ pre_filtered_bi <- reactive({
 
     # raw <- summary()
     raw <- sum %>%
-      filter(!var %in% ms_vars_blocked,
-             !paste(domain, site_code) %in% c("suef C2", "suef C3", "suef C4")
-             )
+      filter(!var %in% ms_vars_blocked)
+             # !paste(domain, site_code) %in% c("suef C2", "suef C3", "suef C4")
 
     if (type == "dom") {
         fill <- raw %>%
@@ -765,11 +764,11 @@ output$SUMMARY_BIPLOT <- renderPlotly({
         return(empty_plot)
     }
 
-    # Color blind safe palette
+    # high contrast pallete, original colors genereated by: https://mokole.com/palette.html
     safe_cols <- c(
-        "#88CCEE", "#CC6677", "#DDCC77", "#117733", "#332288", "#AA4499",
-        "#44AA99", "#999933", "#882255", "#661100", "#6699CC", "#888888"
-    )
+      '#2f4f4f','#2e8b57','#800000','#bdb76b','#9acd32','#00008b','#ff0000','#ff8c00','#ffd700',
+      '#00ff00','#ba55d3','#00fa9a','#00ffff','#00bfff','#0000ff','#ff00ff','#dda0dd','#ff1493',
+      '#ffa07a')
 
     x_tvar <- biplot_selection_to_name(
         chem = chem_x,

--- a/server/summary_biplot_server.R
+++ b/server/summary_biplot_server.R
@@ -57,7 +57,7 @@ pre_filtered_bi <- reactive({
     # raw <- summary()
     raw <- sum %>%
       filter(!var %in% ms_vars_blocked,
-             !paste(domain, site_code) %in% c("suef C2", "suef C3", "suef C4")
+             !paste(domain, site_code) %in% c("suef C2", "suef C3", "suef C4"))
 
     if (type == "dom") {
         fill <- raw %>%

--- a/server/summary_biplot_server.R
+++ b/server/summary_biplot_server.R
@@ -56,7 +56,7 @@ pre_filtered_bi <- reactive({
 
     # raw <- summary()
     raw <- sum %>%
-      filter(!var %in% ms_vars_blocked)
+      filter(!var %in% ms_vars_blocked,
              !paste(domain, site_code) %in% c("suef C2", "suef C3", "suef C4")
 
     if (type == "dom") {

--- a/server/summary_biplot_server.R
+++ b/server/summary_biplot_server.R
@@ -766,9 +766,26 @@ output$SUMMARY_BIPLOT <- renderPlotly({
 
     # high contrast pallete, original colors genereated by: https://mokole.com/palette.html
     safe_cols <- c(
-      '#00ff00','#ba55d3','#00fa9a','#00ffff','#00bfff','#0000ff','#ff00ff','#dda0dd','#ff1493',
-      '#2f4f4f','#2e8b57','#800000','#bdb76b','#9acd32','#00008b','#ff0000','#ff8c00','#ffd700',
-      '#ffa07a')
+      '#800000',
+      '#00ff00',
+      '#ba55d3',
+      '#ffd700',
+      '#00ffff',
+      '#ff1493',
+      '#0000ff',
+      '#2e8b57',
+      '#ff00ff',
+      '#9acd32',
+      '#00bfff',
+      '#2f4f4f',
+      '#00fa9a',
+      '#00008b',
+      '#ff0000',
+      '#ff8c00',
+      '#dda0dd',
+      '#ffa07a',
+      '#bdb76b'
+    )
 
     x_tvar <- biplot_selection_to_name(
         chem = chem_x,

--- a/server/summary_biplot_server.R
+++ b/server/summary_biplot_server.R
@@ -766,8 +766,8 @@ output$SUMMARY_BIPLOT <- renderPlotly({
 
     # high contrast pallete, original colors genereated by: https://mokole.com/palette.html
     safe_cols <- c(
-      '#2f4f4f','#2e8b57','#800000','#bdb76b','#9acd32','#00008b','#ff0000','#ff8c00','#ffd700',
       '#00ff00','#ba55d3','#00fa9a','#00ffff','#00bfff','#0000ff','#ff00ff','#dda0dd','#ff1493',
+      '#2f4f4f','#2e8b57','#800000','#bdb76b','#9acd32','#00008b','#ff0000','#ff8c00','#ffd700',
       '#ffa07a')
 
     x_tvar <- biplot_selection_to_name(

--- a/server/summary_biplot_server.R
+++ b/server/summary_biplot_server.R
@@ -57,7 +57,7 @@ pre_filtered_bi <- reactive({
     # raw <- summary()
     raw <- sum %>%
       filter(!var %in% ms_vars_blocked)
-             # !paste(domain, site_code) %in% c("suef C2", "suef C3", "suef C4")
+             !paste(domain, site_code) %in% c("suef C2", "suef C3", "suef C4")
 
     if (type == "dom") {
         fill <- raw %>%


### PR DESCRIPTION
the highest ratio of commits:content in history, here is a color update for our biplot to have higher contrast colors. 

[Here is a simulator for different types of color vision capacities](https://www.color-blindness.com/coblis-color-blindness-simulator/) where one can paste the image below in and get a sense of where this palette is strong and weak in terms of different types of color vision. In my research I have found a maximum of ten-color high-contrast and safe color pallettes. [Here is a website with one](https://thenode.biologists.com/data-visualization-with-flying-colors/research/) we could use which has ten colors, and bright/muted/light versions of this ten color pallete. Four our context where we need to have ~20 colors for the all-domain biplot, I'm wondering wether we should pursue using the bright and muted version of this pallette, or pursue using different outline types, etc. Regardless, submitting PR for higher contrast colors now, but wanted to make note of these considerations for future updates if we can find a way to have a high-contrast palette with 20 colors which is distinct across color vision types.

Screenshot from portal:
![image](https://user-images.githubusercontent.com/63979914/226679619-4665918d-dcf3-4fed-b61b-4d922d396320.png)


Screenshot example from different types of color vision simulator:
![image](https://user-images.githubusercontent.com/63979914/226679709-0c3736e5-404c-4cd4-881a-dcdae52f52d1.png)
![image](https://user-images.githubusercontent.com/63979914/226679820-a3a8344a-4828-4027-a4b6-5ac166958bf9.png)



